### PR TITLE
Remove - unused seed socket emit

### DIFF
--- a/unity/LockstepIO/LockstepIOComponent.cs
+++ b/unity/LockstepIO/LockstepIOComponent.cs
@@ -140,7 +140,6 @@ public class LockstepIOComponent : MonoBehaviour
 		JSONObject ntp = JSONObject.Create(JSONObject.JSONType.OBJECT);
 		ntp.AddField("t0", (double)LocalNow);
 		Socket.Emit("lockstep.io:sync", ntp);
-		Socket.Emit("lockstep.io:seed", new JSONObject());
 	}
 	
 	private void OnLockstepSync(SocketIOEvent evt)


### PR DESCRIPTION
Node JS doesnt react to this Emit, it doesn't seem to be needed.
Socket.Emit("lockstep.io:seed", new JSONObject());
